### PR TITLE
Add configurable assistant greeting message

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -51,7 +51,10 @@ with st.sidebar:
 # Main app loop
 # Initialize chat messages in session state rith a greeting
 if "messages" not in st.session_state:
-    st.session_state["messages"] = [{"role": "assistant", "content": "How can I help you?"}]
+    if config.STREAMLIT_OLLAMA_ASSISTANT_GREETING:
+        st.session_state["messages"] = [{"role": "assistant", "content": config.STREAMLIT_OLLAMA_ASSISTANT_GREETING}]
+    else:
+        st.session_state["messages"] = []
 
 # Display all messages in the chat history
 # This will re-render on each interaction

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,11 @@ STREAMLIT_OLLAMA_LOG_FORMAT: str = "%(asctime)s: %(levelname)s: %(message)s"
 STREAMLIT_OLLAMA_ASSISTANT_AVATAR: str = "images/ollama-avatar.png"
 STREAMLIT_OLLAMA_USER_AVATAR: str = None
 
+# Custom greeting message for the assistant
+# This will be the initial message from the assistant when the chat starts
+# If set to None or an empty string, no greeting will be shown
+STREAMLIT_OLLAMA_ASSISTANT_GREETING: str = "How can I help you?"
+
 
 def logger(level: str = STREAMLIT_OLLAMA_LOG_LEVEL, 
            format: str = STREAMLIT_OLLAMA_LOG_FORMAT) -> logging.Logger:


### PR DESCRIPTION
Introduces STREAMLIT_OLLAMA_ASSISTANT_GREETING in config.py to allow customization of the assistant's initial greeting. The app now uses this value for the first chat message, or starts with an empty history if unset.